### PR TITLE
Changes to pull in JSBuilder2 for creating RM JS file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zenoss/zenoss-centos-base:1.1.4
+FROM zenoss/zenoss-centos-base:1.2.1
 MAINTAINER Zenoss <ian@zenoss.com>
 
 # add chrome for headless browser testing
@@ -32,7 +32,7 @@ RUN yum install epel-release -y \
     swig \
     which \
     bc \
-    java-1.7.0-openjdk-devel \
+    java-1.8.0-openjdk-devel \
     unzip \
     patch \
     gcc \


### PR DESCRIPTION
Use zenoss-centos-base version that includes JSBuilder2 (which has Java 8 runtime), and 
update JDK to version 8.