### PR TITLE
ZING-1669: Add libuuid-devel to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN yum install epel-release -y \
     xorg-x11-server-Xvfb \
     supervisor \
     google-chrome-stable \
+    libuuid-devel \
     && yum erase epel-release -y \
     && /sbin/scrub.sh
 


### PR DESCRIPTION
Fixes ZING-1669

* Updated nginx pagespeed requires libuuid